### PR TITLE
refactor: replace `chalk` with `@griseo.js/brush`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "release": "npm run build && npm publish --access public"
   },
   "dependencies": {
+    "@griseo.js/brush": "^1.4.2",
     "@inquirer/select": "^1.2.1",
     "chalk": "4.1.2",
     "inquirer": "8.2.5",

--- a/src/add/index.ts
+++ b/src/add/index.ts
@@ -1,5 +1,5 @@
 import i from 'inquirer'
-import chalk from 'chalk'
+import brush from '@griseo.js/brush'
 
 import bearer, { dependencies as bearerDeps } from './bearer'
 import cookie, { dependencies as cookieDeps } from './cookie'
@@ -48,7 +48,7 @@ export const addOptions = async () => {
 const add = async (action: string) => {
     if (!plugins.includes(action as any))
         return console.log(
-            'Plugin ' + chalk.red(action) + ' not found, skip...'
+            'Plugin ' + brush.red(action) + ' not found, skip...'
         )
 
     const deps = depsMap[action as keyof typeof depsMap]

--- a/src/elf.ts
+++ b/src/elf.ts
@@ -10,7 +10,7 @@ import { install } from './utils'
 import type { ParsedArgs } from 'minimist'
 
 import info from '../package.json'
-import chalk from 'chalk'
+import brush from '@griseo.js/brush'
 
 const argv: ParsedArgs = require('minimist')(process.argv.slice(2))
 let {
@@ -69,7 +69,7 @@ const main = async () => {
             case 'v':
             case 'version':
                 console.log(
-                    chalk.cyanBright.bold('Elf Elysia') + ' - ' + info.description
+                    brush.cyanBright.bold('Elf Elysia') + ' - ' + info.description
                 )
                 console.log('version: ' + info.version)
 
@@ -79,7 +79,7 @@ const main = async () => {
 
             default:
                 cmdNotFound = true
-                console.log(`${chalk.bold(action)} command not found`)
+                console.log(`${brush.bold(action)} command not found`)
         }
     }
 

--- a/src/generate/auth/drizzle/index.ts
+++ b/src/generate/auth/drizzle/index.ts
@@ -1,6 +1,6 @@
 import i from 'inquirer'
 import select, { Separator } from '@inquirer/select'
-import c from 'chalk'
+import brush from '@griseo.js/brush'
 import { $, cd } from 'zx-cjs'
 
 import task from 'tasuku'

--- a/src/generate/auth/oauth/index.ts
+++ b/src/generate/auth/oauth/index.ts
@@ -1,6 +1,6 @@
 import i from 'inquirer'
 import select, { Separator } from '@inquirer/select'
-import c from 'chalk'
+import brush from '@griseo.js/brush'
 
 import { readFile, writeFile } from 'fs/promises'
 

--- a/src/generate/auth/prisma/index.ts
+++ b/src/generate/auth/prisma/index.ts
@@ -1,6 +1,6 @@
 import i from 'inquirer'
 import select, { Separator } from '@inquirer/select'
-import c from 'chalk'
+import brush from '@griseo.js/brush'
 import { $, cd } from 'zx-cjs'
 
 import task from 'tasuku'

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -1,5 +1,5 @@
 import select from '@inquirer/select'
-import chalk from 'chalk'
+import brush from '@griseo.js/brush'
 
 import auth from './auth'
 import route from './route'
@@ -17,7 +17,7 @@ export const generateOptions = () =>
 const generate = async (action: string) => {
     if (!generators.includes(action as any))
         return console.log(
-            'Generator for ' + chalk.red(action) + ' not found, skip...'
+            'Generator for ' + brush.red(action) + ' not found, skip...'
         )
 
     indent(`Generate ${capitalize(action)}`)

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,11 +1,11 @@
-import { bold } from 'chalk'
+import brush from '@griseo.js/brush'
 
 import { existsSync } from 'fs'
 import { readFile, writeFile } from 'fs/promises'
 
 import { format as formatCode, resolveConfig } from 'prettier'
 
-export const indent = (word: string) => console.log(bold(`\n> ${word}`))
+export const indent = (word: string) => console.log(brush.bold(`\n> ${word}`))
 
 export const capitalize = (word: string) =>
     word.charAt(0).toUpperCase() + word.slice(1)


### PR DESCRIPTION
# Summary
Swap out chalk for Griseo's brush.

# Motivation
Chalk is good, but Elf Elysia loves Griseo (and her brush) more?  `@griseo.js/brush` is a personal project I wrote as a drop-in replacement for terminal string stylers (i.e. Chalk, Kleur). There's nothing too special about this project, besides being comparable to other solutions. But I'd love if you could check it out! :pray:

![image](https://github.com/elysiajs/elf/assets/66761366/850a2df1-e172-4d2f-9024-844e65bb3150)

# More
- NPM package: https://www.npmjs.com/package/@griseo.js/brush
- Repository: https://github.com/Elysium-Everlasting/griseo.js

![](https://media.tenor.com/YdubPv2HUnkAAAAC/elysia-honkai-impact.gif)